### PR TITLE
feat: update authentication flow and add login page

### DIFF
--- a/app/(auth)/join-game/__tests__/page.test.tsx
+++ b/app/(auth)/join-game/__tests__/page.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useSearchParams } from "next/navigation";
+import useInviteActions from "@/store/invite/actions";
+import useSystemFunctions from "@/hooks/useSystemFunctions";
+import JoinGame from "../page";
+
+// Mock hooks
+jest.mock("@privy-io/react-auth", () => ({
+  usePrivy: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("@/store/invite/actions", () => jest.fn());
+
+jest.mock("@/hooks/useSystemFunctions", () => jest.fn());
+
+// Mock the components used in JoinGame
+jest.mock("@/components", () => ({
+  KPDialougue: ({
+    title,
+    children,
+    primaryCta,
+    showCloseButton,
+    className,
+  }: any) => (
+    <div data-testid="kp-dialogue">
+      <h2>{title}</h2>
+      {children}
+      {primaryCta && (
+        <button
+          data-testid={`primary-cta-${primaryCta.title}`}
+          onClick={primaryCta.onClick}
+          disabled={primaryCta.disabled}
+        >
+          {primaryCta.title}
+          {primaryCta.loading && <span data-testid="loading-indicator">...</span>}
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+describe("JoinGame Page", () => {
+  // Mock implementation setup
+  const mockAcceptInvite = jest.fn();
+  const mockGet = jest.fn();
+  const mockNavigatePush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup search params mock
+    mockGet.mockReturnValue("ABCD1234");
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: mockGet,
+    });
+
+    // Setup usePrivy mock
+    (usePrivy as jest.Mock).mockReturnValue({
+      user: { id: "user-123" },
+      ready: true,
+    });
+
+    // Setup invite actions mock
+    (useInviteActions as jest.Mock).mockReturnValue({
+      acceptInvite: mockAcceptInvite,
+    });
+
+    // Setup system functions mock
+    (useSystemFunctions as jest.Mock).mockReturnValue({
+      inviteState: {
+        loadingInviteAcceptance: false,
+      },
+      navigate: {
+        push: mockNavigatePush,
+      },
+    });
+  });
+
+  it("doesn't render content when not ready", () => {
+    // Set ready to false
+    (usePrivy as jest.Mock).mockReturnValue({
+      user: null,
+      ready: false,
+    });
+
+    render(<JoinGame />);
+    // The component just returns undefined when not ready, so we should not see any content
+    expect(screen.queryByTestId("kp-dialogue")).not.toBeInTheDocument();
+  });
+
+  it("redirects to login when not logged in but has code", () => {
+    // Set user to null to simulate not logged in
+    (usePrivy as jest.Mock).mockReturnValue({
+      user: null,
+      ready: true,
+    });
+
+    render(<JoinGame />);
+    
+    // Should redirect to login
+    expect(mockNavigatePush).toHaveBeenCalledWith("/login");
+    expect(global.sessionStorage.getItem("redirectToJoin")).toBe("ABCD1234");
+  });
+
+  it("attempts to join a game with the code from URL when logged in", async () => {
+    render(<JoinGame />);
+
+    // Should attempt to join the game
+    await waitFor(() => {
+      expect(mockAcceptInvite).toHaveBeenCalledWith("ABCD1234");
+    });
+  });
+
+  it("displays error message when join fails", async () => {
+    // Mock the acceptInvite to throw an error
+    mockAcceptInvite.mockRejectedValueOnce(new Error("Failed to join"));
+
+    render(<JoinGame />);
+
+    // Wait for the error message to appear
+    await waitFor(() => {
+      expect(screen.getByText("Failed to join the game. Please try again later.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state during invitation acceptance", () => {
+    // Mock loading state
+    (useSystemFunctions as jest.Mock).mockReturnValue({
+      inviteState: {
+        loadingInviteAcceptance: true,
+      },
+      navigate: {
+        push: mockNavigatePush,
+      },
+    });
+
+    render(<JoinGame />);
+    
+    expect(screen.getByTestId("primary-cta-Joining...")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+  });
+
+  it("displays the invite code when available", () => {
+    render(<JoinGame />);
+    
+    expect(screen.getByText("ABCD1234")).toBeInTheDocument();
+  });
+});

--- a/app/(auth)/join-game/page.tsx
+++ b/app/(auth)/join-game/page.tsx
@@ -24,7 +24,7 @@ const JoinGameComponent = () => {
 
     if (!user && code) {
       sessionStorage.setItem("redirectToJoin", code);
-      navigate.push("/connect");
+      navigate.push("/login");
     }
 
     if (user && code) {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, JSX } from "react";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
-import { useLinkAccount } from "@privy-io/react-auth";
+import { usePrivy } from "@privy-io/react-auth";
 
 import {
   KPButton,
@@ -13,6 +13,7 @@ import {
 } from "@/components";
 import { CheckIcon } from "@/public/icons";
 import useSystemFunctions from "@/hooks/useSystemFunctions";
+import usePrivyLinkedAccounts from "@/hooks/usePrivyLinkedAccounts";
 
 const friends = [
   { name: "Kripson", image: "/images/kripson.jpeg" },
@@ -21,35 +22,14 @@ const friends = [
 ];
 
 const Social = () => {
-  const { linkTwitter, linkFarcaster } = useLinkAccount({
-    onSuccess: () => {
-      setShowSpinner(false);
-      setStage("connected");
-    },
-    onError: (error) => {
-      console.error("LINK FARCaster ERROR:", error);
-      setShowSpinner(false);
-    },
-  });
+  const { user, ready, login } = usePrivy();
+  const { linkedFarcaster, linkedTwitter } = usePrivyLinkedAccounts();
   const { navigate } = useSystemFunctions();
 
   const [stage, setStage] = useState<"connect" | "connected" | "setup">(
     "connect"
   );
   const [showSpinner, setShowSpinner] = useState(false);
-
-  const connectionOptions: Array<IKPButton> = [
-    {
-      title: "Connect with farcaster",
-      icon: "farcaster",
-      onClick: linkFarcaster,
-    },
-    {
-      title: "Connect with twitter",
-      icon: "x",
-      onClick: linkTwitter,
-    },
-  ];
 
   useEffect(() => {
     if (stage === "connected") {
@@ -68,53 +48,66 @@ const Social = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stage]);
 
+  useEffect(() => {
+    if (ready && user) {
+      setShowSpinner(false);
+      setStage("connected");
+    }
+  }, [ready, user]);
+
   const dialogues: Record<string, JSX.Element> = {
     connect: (
       <KPDialougue
-        title="connect your socials"
+        title="connect with your social"
         subtitle="Play with your frens. Share your wins. See who’s already in the fleet."
         showCloseButton
         onClose={() => {}}
         showKripsonImage
-        primaryCta={{
-          title: "skip for now",
-          onClick: () => setStage("setup"),
-          variant: "tertiary",
-        }}
       >
         <div className="w-full flex flex-col items-stretch mt-5 gap-1">
-          {connectionOptions.map((option, index) => (
-            <KPButton
-              key={index}
-              {...option}
-              variant="primary"
-              isMachine
-              fullWidth
-            />
-          ))}
+          <KPButton
+            title="Connect"
+            onClick={login}
+            variant="primary"
+            isMachine
+            fullWidth
+            multipleicons={["x", "farcaster"]}
+          />
         </div>
       </KPDialougue>
     ),
 
     connected: (
       <KPDialougue
-        title="connect with farcaster"
+        title="connect with your social"
         subtitle="Play with your frens. Share your wins. See who’s already in the fleet."
         showCloseButton
-        showBackButton
         onClose={() => {}}
-        ctaText="Farcaster Connected"
+        ctaText="Connected"
       >
         <div className="flex flex-col items-center justify-center self-stretch w-full gap-5 text-center">
           <div className="size-[84px] max-sm:size-[56.14px] rounded-lg bg-white flex items-center justify-center relative">
-            <Image
-              src="/images/farcaster.png"
-              alt="farcaster"
-              width={64}
-              height={64}
-              quality={100}
-              className="size-16 max-sm:size-[42.78px] object-cover rounded-md"
-            />
+            {linkedFarcaster && (
+              <Image
+                src="/images/farcaster.png"
+                alt="farcaster"
+                width={64}
+                height={64}
+                quality={100}
+                className="size-16 max-sm:size-[42.78px] object-cover rounded-md"
+              />
+            )}
+
+            {linkedTwitter && (
+              <Image
+                src="/images/x.png"
+                alt="twitter"
+                width={64}
+                height={64}
+                quality={100}
+                className="size-16 max-sm:size-[42.78px] object-cover rounded-md"
+              />
+            )}
             <div className="absolute right-1 bottom-4 max-sm:bottom-2">
               <CheckIcon className="max-sm:size-[17.38px]" />
             </div>

--- a/app/(auth)/new-game/__tests__/page.test.tsx
+++ b/app/(auth)/new-game/__tests__/page.test.tsx
@@ -1,0 +1,373 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import useInviteActions from "@/store/invite/actions";
+import useSystemFunctions from "@/hooks/useSystemFunctions";
+import usePrivyLinkedAccounts from "@/hooks/usePrivyLinkedAccounts";
+import useCopy from "@/hooks/useCopy";
+import useAppActions from "@/store/app/actions";
+import { useAudio } from "@/providers/AudioProvider";
+import NewGame from "../page";
+
+// Mock the hooks
+jest.mock("react-hook-form", () => ({
+  useForm: jest.fn(),
+}));
+
+jest.mock("@/store/invite/actions", () => jest.fn());
+jest.mock("@/hooks/useSystemFunctions", () => jest.fn());
+jest.mock("@/hooks/usePrivyLinkedAccounts", () => jest.fn());
+jest.mock("@/hooks/useCopy", () => jest.fn());
+jest.mock("@/store/app/actions", () => jest.fn());
+jest.mock("@/providers/AudioProvider", () => ({
+  useAudio: jest.fn(),
+}));
+
+// Mock framer-motion to prevent animation issues in tests
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: any) => (
+      <div data-testid="motion-div" {...props}>
+        {children}
+      </div>
+    ),
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+// Mock all components used in the NewGame page
+jest.mock("@/components", () => ({
+  KPButton: ({
+    title,
+    onClick,
+    disabled,
+    isMachine,
+    fullWidth,
+    ...props
+  }: any) => (
+    <button
+      data-testid={`kp-button-${title}`}
+      onClick={onClick}
+      disabled={disabled}
+      {...props}
+    >
+      {title}
+    </button>
+  ),
+  KPDialougue: ({
+    title,
+    children,
+    primaryCta,
+    showCloseButton,
+    showBackButton,
+    onBack,
+    className,
+  }: any) => (
+    <div data-testid="kp-dialogue">
+      <h2>{title}</h2>
+      {children}
+      {showBackButton && (
+        <button onClick={onBack} data-testid="back-button">
+          Back
+        </button>
+      )}
+      {primaryCta && (
+        <button
+          onClick={primaryCta.onClick}
+          data-testid={`primary-cta-${primaryCta.title}`}
+          disabled={primaryCta.disabled}
+        >
+          {primaryCta.title}
+          {primaryCta.loading && <span data-testid="loading-indicator">...</span>}
+        </button>
+      )}
+    </div>
+  ),
+  KPGameTypeCard: ({
+    id,
+    name,
+    description,
+    status,
+    className,
+    action,
+    ...props
+  }: any) => (
+    <div
+      data-testid={`game-type-${id}`}
+      className={className}
+      onClick={action}
+      {...props}
+    >
+      <h3>{name}</h3>
+      <p>{description}</p>
+      {status && <span data-testid="status-badge">{status}</span>}
+    </div>
+  ),
+  KPInput: ({
+    name,
+    placeholder,
+    register,
+    error,
+    className,
+    type,
+    ...props
+  }: any) => (
+    <input
+      data-testid={`input-${name}`}
+      placeholder={placeholder}
+      {...register}
+      {...props}
+    />
+  ),
+  KPProfileBadge: ({ avatarUrl, username, ...props }: any) => (
+    <div data-testid="profile-badge" {...props}>
+      {username}
+    </div>
+  ),
+}));
+
+describe("NewGame Page", () => {
+  // Mock implementation setup
+  const mockCreateInvite = jest.fn();
+  const mockAcceptInvite = jest.fn();
+  const mockNavigatePush = jest.fn();
+  const mockHandleCopy = jest.fn();
+  const mockShowToast = jest.fn();
+  const mockRegister = jest.fn();
+  const mockHandleSubmit = jest.fn();
+  const mockWatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock form functionality
+    mockWatch.mockReturnValue("ABCD1234");
+    mockHandleSubmit.mockImplementation((callback) => () => callback());
+    
+    (useForm as jest.Mock).mockReturnValue({
+      register: mockRegister,
+      handleSubmit: mockHandleSubmit,
+      formState: { errors: {} },
+      watch: mockWatch,
+    });
+
+    // Mock invite actions
+    (useInviteActions as jest.Mock).mockReturnValue({
+      acceptInvite: mockAcceptInvite,
+      createInvite: mockCreateInvite,
+    });
+
+    // Mock system functions
+    (useSystemFunctions as jest.Mock).mockReturnValue({
+      inviteState: {
+        loadingInviteAcceptance: false,
+        loadingInviteCreation: false,
+        inviteCreation: {
+          code: "ABCD1234",
+          sessionId: "session-123",
+          expiresAt: Date.now() + 3600000, // 1 hour from now
+        },
+      },
+      navigate: {
+        push: mockNavigatePush,
+      },
+    });
+
+    // Mock Privy linked accounts
+    (usePrivyLinkedAccounts as jest.Mock).mockReturnValue({
+      linkedFarcaster: { username: "farcaster_user", pfp: "/images/farcaster.png" },
+      linkedTwitter: null,
+    });
+
+    // Mock copy hook
+    (useCopy as jest.Mock).mockReturnValue({
+      handleCopy: mockHandleCopy,
+    });
+
+    // Mock app actions
+    (useAppActions as jest.Mock).mockReturnValue({
+      showToast: mockShowToast,
+    });
+
+    // Mock audio context
+    (useAudio as jest.Mock).mockReturnValue({
+      playSoundEffect: jest.fn(),
+    });
+
+    // Mock window.navigator.share
+    global.navigator.share = jest.fn().mockResolvedValue(undefined);
+  });
+
+  it("renders the initial join game screen", () => {
+    render(<NewGame />);
+
+    expect(screen.getByText("welcome")).toBeInTheDocument();
+    expect(screen.getByText("choose new game:")).toBeInTheDocument();
+    expect(screen.getByText("Join match:")).toBeInTheDocument();
+    expect(screen.getByTestId("game-type-fm")).toBeInTheDocument();
+    expect(screen.getByTestId("game-type-qm")).toBeInTheDocument();
+    expect(screen.getByTestId("input-code")).toBeInTheDocument();
+    expect(screen.getByTestId("primary-cta-Next")).toBeInTheDocument();
+  });
+
+  it("displays the profile badge with correct username", () => {
+    render(<NewGame />);
+    expect(screen.getByTestId("profile-badge")).toHaveTextContent("farcaster_user");
+  });
+
+  it("transitions to create game screen when friend's match is selected", async () => {
+    render(<NewGame />);
+    
+    // Click on Friend's Match game type
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+      expect(screen.getByText("ABCD1234")).toBeInTheDocument();
+    });
+  });
+
+  it("doesn't transition when clicking on a 'coming soon' game type", () => {
+    render(<NewGame />);
+    
+    // Click on Quick Match game type (which has 'coming soon' status)
+    const quickMatch = screen.getByTestId("game-type-qm");
+    fireEvent.click(quickMatch);
+    
+    // Should still be on the welcome screen
+    expect(screen.getByText("welcome")).toBeInTheDocument();
+    expect(screen.queryByText("add opponent")).not.toBeInTheDocument();
+  });
+
+  it("attempts to accept an invite when code is submitted", () => {
+    render(<NewGame />);
+    
+    // Click the Next button to submit the form
+    const nextButton = screen.getByTestId("primary-cta-Next");
+    fireEvent.click(nextButton);
+    
+    expect(mockAcceptInvite).toHaveBeenCalledWith("ABCD1234");
+  });
+
+  it("creates a new invite when needed", async () => {
+    // Mock expired or missing invite
+    (useSystemFunctions as jest.Mock).mockReturnValue({
+      inviteState: {
+        loadingInviteAcceptance: false,
+        loadingInviteCreation: false,
+        inviteCreation: null,
+      },
+      navigate: {
+        push: mockNavigatePush,
+      },
+    });
+
+    render(<NewGame />);
+    
+    // Click on Friend's Match game type
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    expect(mockCreateInvite).toHaveBeenCalled();
+  });
+
+  it("navigates to the game session when Next is clicked on the create game screen", async () => {
+    render(<NewGame />);
+    
+    // First go to create game screen
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+    });
+    
+    // Click the Next button
+    const nextButton = screen.getByTestId("primary-cta-Next");
+    fireEvent.click(nextButton);
+    
+    expect(mockNavigatePush).toHaveBeenCalledWith("/session-123");
+  });
+
+  it("allows copying the invite code", async () => {
+    render(<NewGame />);
+    
+    // Go to create game screen
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+    });
+    
+    // Click the copy code button
+    const copyButton = screen.getByTestId("kp-button-copy code instead");
+    fireEvent.click(copyButton);
+    
+    expect(mockHandleCopy).toHaveBeenCalledWith("ABCD1234");
+  });
+
+  it("allows sharing the invite link when available", async () => {
+    render(<NewGame />);
+    
+    // Go to create game screen
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+    });
+    
+    // Click the share invite button
+    const shareButton = screen.getByTestId("kp-button-send invite");
+    fireEvent.click(shareButton);
+    
+    expect(navigator.share).toHaveBeenCalledWith({
+      title: "Join My Game!",
+      text: "I'd like to invite you to play with me! Click the link to join.",
+      url: expect.stringContaining("ABCD1234"),
+    });
+  });
+
+  it("shows an error toast when share is cancelled", async () => {
+    // Mock share failure
+    global.navigator.share = jest.fn().mockRejectedValue(new Error("User cancelled"));
+    
+    render(<NewGame />);
+    
+    // Go to create game screen
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+    });
+    
+    // Click the share invite button
+    const shareButton = screen.getByTestId("kp-button-send invite");
+    fireEvent.click(shareButton);
+    
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith("Share Cancelled", "error");
+    });
+  });
+
+  it("can navigate back from create game to join game screen", async () => {
+    render(<NewGame />);
+    
+    // Go to create game screen
+    const friendsMatch = screen.getByTestId("game-type-fm");
+    fireEvent.click(friendsMatch);
+    
+    await waitFor(() => {
+      expect(screen.getByText("add opponent")).toBeInTheDocument();
+    });
+    
+    // Click the back button
+    const backButton = screen.getByTestId("back-button");
+    fireEvent.click(backButton);
+    
+    // Should be back on join game screen
+    expect(screen.getByText("welcome")).toBeInTheDocument();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,23 +4,16 @@ import { usePrivy } from "@privy-io/react-auth";
 import useSystemFunctions from "@/hooks/useSystemFunctions";
 
 export default function HomePage() {
-  const { user, ready, login } = usePrivy();
+  const { user, ready, logout } = usePrivy();
   const { navigate } = useSystemFunctions();
-
-  useEffect(() => {
-    login();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     if (!ready) return;
 
-    console.log("USER:", user);
-
     if (user) {
       navigate.push("/new-game");
     } else {
-      navigate.push("/connect");
+      navigate.push("/login");
     }
   }, [user, navigate, ready]);
 

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -46,6 +46,7 @@ const KPButton = ({
   isMachine = false,
   icon,
   iconPosition = "left",
+  multipleicons,
 }: IKPButton) => {
   const shadowColor = {
     primary: "#632918",
@@ -103,6 +104,20 @@ const KPButton = ({
             </span>
           )}
 
+          {multipleicons && (
+            <div className="flex items-center gap-2">
+              {multipleicons.map((icon) => (
+                <span
+                  key={icon}
+                  className={classNames("flex-shrink-0", {
+                    "mb-1.5": icon !== "x",
+                  })}
+                >
+                  {icons[icon]}
+                </span>
+              ))}
+            </div>
+          )}
           <span
             className={classNames(
               "uppercase text-[26px] max-sm:text-[17.83px] leading-[100%] tracking-[2%]",

--- a/components/button/types.ts
+++ b/components/button/types.ts
@@ -10,6 +10,9 @@ interface IKPButton {
   loading?: boolean;
   className?: string;
   isMachine?: boolean;
-  icon?: "farcaster" | "copy" | "arrow" | "x" | "home" | "replay";
+  icon?: Icons;
   iconPosition?: "left" | "right";
+  multipleicons?: Icons[];
 }
+
+type Icons = "farcaster" | "copy" | "arrow" | "x" | "home" | "replay";

--- a/components/fullscreen-loader/index.tsx
+++ b/components/fullscreen-loader/index.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 
 import useSystemFunctions from "@/hooks/useSystemFunctions";
 
-const authGroup = ["/connect", "/", "/new-game"];
+const authGroup = ["/login", "/", "/new-game"];
 
 const KPFullscreenLoader = ({
   title,

--- a/providers/PrivyProvider.tsx
+++ b/providers/PrivyProvider.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from "react";
 import { PrivyClientConfig, PrivyProvider } from "@privy-io/react-auth";
 
 export const privyConfig: PrivyClientConfig = {
-  loginMethods: ["farcaster", "email", "twitter"],
+  loginMethods: ["farcaster", "twitter"],
   embeddedWallets: {
     ethereum: {
       createOnLogin: "all-users",


### PR DESCRIPTION
- Replace "/connect" with "/login" in navigation for unauthenticated users.
- Implement new login page with social connection options and loading states.
- Add tests for login functionality and user flow.
- Remove email login method from Privy configuration.